### PR TITLE
Update Dockerfile to install vcf-annotation-tools from PyPi instead of TestPyPi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update -y && apt-get install -y \
     python3 \
     python3-pip
 
-RUN pip3 install vcf-annotation-tools
+RUN pip3 install vcf-annotation-tools==1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:xenial
 MAINTAINER John Garza <johnegarza@wustl.edu>
 
 LABEL \
-    description="Image containing the vcf-anootation-tools python package" \
+    description="Image containing the vcf-annotation-tools python package" \
     version="1.0.0"
 
 RUN apt-get update -y && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:xenial
 MAINTAINER John Garza <johnegarza@wustl.edu>
 
 LABEL \
-    description="Image containing the vcf-anootation-tools python package"
+    description="Image containing the vcf-anootation-tools python package" \
+    version="1.0.0"
 
 RUN apt-get update -y && apt-get install -y \
     apt-utils \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,7 @@ LABEL \
 
 RUN apt-get update -y && apt-get install -y \
     apt-utils \
-    python \
-    python-pip \
     python3 \
     python3-pip
 
-RUN pip install --upgrade pip
 RUN pip3 install --extra-index-url https://testpypi.python.org/pypi vcf-annotation-tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update -y && apt-get install -y \
     python3 \
     python3-pip
 
-RUN pip3 install --extra-index-url https://testpypi.python.org/pypi vcf-annotation-tools
+RUN pip3 install vcf-annotation-tools


### PR DESCRIPTION
This package has been released into the wild so we can install directly from PyPi instead of TestPyPi. By pinning the version of the package we also ensure that version 1.0.0 gets installed every time this docker container gets build, even if the package version has increased. 

This PR also cleans up the Dockerfile a bit (remove unneeded installs, fix typo, and set a version).