### PR TITLE
Upgrade to a higher ubuntu version to get python>=3.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 MAINTAINER Susanna Kiwala <susanna.kiwala@wustl.edu>
 
 LABEL \


### PR DESCRIPTION
The version installed in xenial 3.5.2 which was causing some pandas syntax errors.